### PR TITLE
Troubleshoot recovery mode data access failure

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -30,6 +30,15 @@ PRODUCT_PACKAGES += \
     android.hardware.health@2.1-service \
     android.hardware.health@2.1-impl
 
+# Keymaster/Gatekeeper/Keystore services required for FBE decryption
+PRODUCT_PACKAGES += \
+    android.hardware.gatekeeper@1.0-service \
+    android.hardware.keymaster@4.0-service.mitee \
+    android.hardware.keymaster@4.0-service.beanpod \
+    keystore_auth \
+    keystore \
+    vendor.xiaomi.hardware.vibratorfeature.service
+
 # ------------------------------------------------------------------------------
 # CRITICAL FIXES FOR DECRYPTION
 # ------------------------------------------------------------------------------

--- a/recovery.fstab
+++ b/recovery.fstab
@@ -12,10 +12,10 @@
 /odm			ext4	ro,barrier=1	wait,logical,slotselect
 
 # Data and Metadata Partitions (Read-Write)
-/data			ext4	noatime,nosuid,nodev,noauto_da_alloc,barrier=1,data=ordered	wait,check,formattable,resize,encryptable=footer
-/data			f2fs	noatime,nosuid,nodev,background_gc=on,discard,user_xattr,acl,inline_data,inline_dentry,flush_merge,extent_cache,mode=adaptive,active_logs=6	wait,check,formattable,resize,encryptable=footer
+/data			ext4	noatime,nosuid,nodev,discard,barrier=1,data=ordered	wait,check,formattable,quota,latemount,resize,fileencryption=aes-256-xts:aes-256-cts:v2,metadata_encryption=aes-256-xts:wrappedkey_v0,keydirectory=/metadata/vold/metadata_encryption
+/data			f2fs	noatime,nosuid,nodev,discard,background_gc=on,user_xattr,acl,inline_data,inline_dentry,flush_merge,extent_cache,mode=adaptive,active_logs=6	wait,check,formattable,quota,latemount,resize,fileencryption=aes-256-xts:aes-256-cts:v2,metadata_encryption=aes-256-xts:wrappedkey_v0,keydirectory=/metadata/vold/metadata_encryption,fscompress
 
-/metadata		ext4	noatime,nosuid,nodev,discard	wait,check,formattable
+/metadata		ext4	nosuid,nodev,discard	wait,check,formattable
 
 # Cache Partition
 /cache			ext4	noatime,nosuid,nodev,discard	wait,check,formattable
@@ -66,7 +66,7 @@ f2fs			/dev/block/*		/data			flags=display="Data";backup=1;flashimg=1
 f2fs			/dev/block/*		/cache			flags=display="Cache";backup=1;wipeingui=1;flashimg=1
 
 # Filesystem Detection
-auto			/dev/block/bootdevice/by-name/userdata		/data			flags=length=-16384;encryptable=footer
+auto			/dev/block/bootdevice/by-name/userdata		/data			flags=length=-16384
 auto			/dev/block/bootdevice/by-name/cache		/cache			flags=wipeingui
 
 # Fallback entries for block device mapping

--- a/recovery/root/ueventd.mt6893.rc
+++ b/recovery/root/ueventd.mt6893.rc
@@ -27,6 +27,10 @@
 /dev/block/by-name/md1dsp    0660    root    system
 /dev/block/by-name/boot_para 0640    root    system
 
+# userdata and metadata for vold access
+/dev/block/bootdevice/by-name/userdata 0660 root system
+/dev/block/bootdevice/by-name/metadata 0660 root system
+
 # OTP
 /dev/otp                  0660   system     system
 /dev/block/platform/bootdevice/by-name/otp       0660    root    system

--- a/recovery/root/vendor/ueventd.mt6893.rc
+++ b/recovery/root/vendor/ueventd.mt6893.rc
@@ -27,6 +27,10 @@
 /dev/block/by-name/md1dsp    0660    root    system
 /dev/block/by-name/boot_para 0640    root    system
 
+# userdata and metadata for vold access
+/dev/block/bootdevice/by-name/userdata 0660 root system
+/dev/block/bootdevice/by-name/metadata 0660 root system
+
 # OTP
 /dev/otp                  0660   system     system
 /dev/block/platform/bootdevice/by-name/otp       0660    root    system


### PR DESCRIPTION
Fix TWRP 'unable to access data' by updating FBE flags, adding decryption services, and setting ueventd permissions.

The "unable to access data" error was caused by TWRP's inability to decrypt and mount the `/data` partition on Android 12+ devices, especially those with MediaTek SoCs. This PR updates `recovery.fstab` with modern FBE flags (including `metadata_encryption` with `wrappedkey_v0` and `keydirectory`), includes necessary keymaster/gatekeeper/keystore services for `vold` decryption, and adjusts `ueventd` rules to grant recovery access to the `userdata` and `metadata` block devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-b607e73a-58ae-4536-96d3-2b00cec0d84e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b607e73a-58ae-4536-96d3-2b00cec0d84e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

